### PR TITLE
ignore-decode-error

### DIFF
--- a/packages/signer-test/src/agentChannel.ts
+++ b/packages/signer-test/src/agentChannel.ts
@@ -132,12 +132,12 @@ export class AgentChannel implements Channel {
             : undefined;
         const expiration = new Date(
           Date.now() +
-            Number(
-              delegationRequest.params!.maxTimeToLive
-                ? BigInt(delegationRequest.params!.maxTimeToLive) /
-                    BigInt(1_000_000)
-                : BigInt(8) * BigInt(3_600_000),
-            ),
+          Number(
+            delegationRequest.params!.maxTimeToLive
+              ? BigInt(delegationRequest.params!.maxTimeToLive) /
+              BigInt(1_000_000)
+              : BigInt(8) * BigInt(3_600_000),
+          ),
         );
         const signedDelegationChain = await DelegationChain.create(
           identity,
@@ -162,10 +162,10 @@ export class AgentChannel implements Channel {
                   expiration: delegation.expiration.toString(),
                   ...(delegation.targets
                     ? {
-                        targets: delegation.targets.map((target) =>
-                          target.toText(),
-                        ),
-                      }
+                      targets: delegation.targets.map((target) =>
+                        target.toText(),
+                      ),
+                    }
                     : {}),
                 },
                 signature: toBase64(signature),
@@ -225,29 +225,29 @@ export class AgentChannel implements Channel {
         const { pollForResponse, defaultStrategy } = polling;
         const validationActor = batchCallCanisterRequest.params?.validation
           ? Actor.createActor(
-              ({ IDL }) =>
-                IDL.Service({
-                  [batchCallCanisterRequest.params!.validation!.method]:
-                    IDL.Func(
-                      [
-                        IDL.Record({
-                          canister_id: IDL.Principal,
-                          method: IDL.Text,
-                          arg: IDL.Vec(IDL.Nat8),
-                          res: IDL.Vec(IDL.Nat8),
-                          nonce: IDL.Opt(IDL.Vec(IDL.Nat8)),
-                        }),
-                      ],
-                      [IDL.Bool],
-                      [],
-                    ),
-                }),
-              {
-                canisterId:
-                  batchCallCanisterRequest.params?.validation?.canisterId,
-                agent: this.#agent,
-              },
-            )
+            ({ IDL }) =>
+              IDL.Service({
+                [batchCallCanisterRequest.params!.validation!.method]:
+                  IDL.Func(
+                    [
+                      IDL.Record({
+                        canister_id: IDL.Principal,
+                        method: IDL.Text,
+                        arg: IDL.Vec(IDL.Nat8),
+                        res: IDL.Vec(IDL.Nat8),
+                        nonce: IDL.Opt(IDL.Vec(IDL.Nat8)),
+                      }),
+                    ],
+                    [IDL.Bool],
+                    [],
+                  ),
+              }),
+            {
+              canisterId:
+                batchCallCanisterRequest.params?.validation?.canisterId,
+              agent: this.#agent,
+            },
+          )
           : undefined;
         const batchCallCanisterResponse: BatchCallCanisterResponse = {
           id,
@@ -315,7 +315,7 @@ export class AgentChannel implements Channel {
                   if (
                     status.status !== LookupStatus.Found ||
                     new TextDecoder().decode(status.value as ArrayBuffer) !==
-                      "replied" ||
+                    "replied" ||
                     reply.status !== LookupStatus.Found
                   ) {
                     batchFailed = true;
@@ -333,18 +333,24 @@ export class AgentChannel implements Channel {
                     request.method.startsWith("icrc37_")
                   ) {
                     // Built in validation, basically checks if variant with Err is returned
-                    const value = IDL.decode(
-                      [IDL.Variant({ Err: IDL.Reserved })],
-                      reply.value as ArrayBuffer,
-                    );
-                    if ("Err" in value) {
-                      batchFailed = true;
-                      return {
-                        error: {
-                          code: 1002,
-                          message: "Validation failed.",
-                        },
-                      };
+                    try {
+                      const value = IDL.decode(
+                        [IDL.Variant({ Err: IDL.Reserved })],
+                        reply.value as ArrayBuffer
+                      );
+                      if ("Err" in value) {
+                        batchFailed = true;
+                        return {
+                          error: {
+                            code: 1002,
+                            message: "Validation failed.",
+                          },
+                        };
+                      }
+                    }
+                    catch {
+                      // If this return error likely the response is not included Err variant
+                      // so we can assume it's valid
                     }
                   } else if (validationActor) {
                     if (

--- a/packages/signer-test/src/agentChannel.ts
+++ b/packages/signer-test/src/agentChannel.ts
@@ -206,7 +206,7 @@ export class AgentChannel implements Channel {
         const { certificate } = await agent.readState(canisterId, {
           paths: [
             [
-              new TextEncoder().encode("request_status"),
+              new TextEncoder().encode("request_status").buffer,
               submitResponse.requestId,
             ],
           ],
@@ -292,7 +292,7 @@ export class AgentChannel implements Channel {
                   const { certificate } = await agent.readState(canisterId, {
                     paths: [
                       [
-                        new TextEncoder().encode("request_status"),
+                        new TextEncoder().encode("request_status").buffer,
                         submitResponse.requestId,
                       ],
                     ],

--- a/packages/signer-test/src/constants.ts
+++ b/packages/signer-test/src/constants.ts
@@ -43,28 +43,30 @@ export const scopes: Array<{
   scope: PermissionScope;
   state: PermissionState;
 }> = [
-  {
-    scope: {
-      method: "icrc27_accounts",
+    {
+      scope: {
+        method: "icrc27_accounts",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc34_delegation",
+    {
+      scope: {
+        method: "icrc34_delegation",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc49_call_canister",
+    {
+      scope: {
+        method: "icrc49_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc112_batch_call_canister",
+    {
+      scope: {
+        method: "icrc112_batch_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-];
+  ];
+
+export const ICRC_114_METHOD_NAME = "icrc114_validate";

--- a/packages/signer/src/icrc112/batchCallCanister.ts
+++ b/packages/signer/src/icrc112/batchCallCanister.ts
@@ -19,23 +19,20 @@ export type BatchCallCanisterRequest = JsonRequest<
       arg: string;
       nonce?: string;
     }[][];
-    validation?: {
-      canisterId: string;
-      method: string;
-    };
+    validationCanisterId?: string;
   }
 >;
 
 export type BatchCallCanisterResponse = JsonResponse<{
   responses: (
     | {
-        result: {
-          contentMap: string;
-          certificate: string;
-        };
-      }
+      result: {
+        contentMap: string;
+        certificate: string;
+      };
+    }
     | {
-        error: JsonError;
-      }
+      error: JsonError;
+    }
   )[][];
 }>;

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -145,7 +145,7 @@ export class Signer<T extends Transport = Transport> {
     // Establish a new transport channel
     const channel = this.#options.transport.establishChannel();
     // Indicate that transport channel is being established
-    this.#establishingChannel = channel.then(() => {}).catch(() => {});
+    this.#establishingChannel = channel.then(() => { }).catch(() => { });
     // Clear previous transport channel
     this.#channel = undefined;
     // Assign transport channel once established
@@ -364,18 +364,18 @@ export class Signer<T extends Transport = Transport> {
       method: string;
       arg: ArrayBuffer;
     }[][];
-    validation?: { canisterId: Principal; method: string };
+    validationCanisterId?: Principal;
   }): Promise<
     (
       | {
-          result: {
-            contentMap: ArrayBuffer;
-            certificate: ArrayBuffer;
-          };
-        }
+        result: {
+          contentMap: ArrayBuffer;
+          certificate: ArrayBuffer;
+        };
+      }
       | {
-          error: JsonError;
-        }
+        error: JsonError;
+      }
     )[][]
   > {
     const response = await this.sendRequest<
@@ -394,12 +394,7 @@ export class Signer<T extends Transport = Transport> {
             arg: toBase64(request.arg),
           })),
         ),
-        validation: params.validation
-          ? {
-              canisterId: params.validation.canisterId.toText(),
-              method: params.validation.method,
-            }
-          : undefined,
+        validationCanisterId: params.validationCanisterId?.toText(),
       },
     });
     const result = unwrapResponse(response);


### PR DESCRIPTION
The decode response for ICRC1, 2, 7, 37 will always return error if the response return 
```
{
Ok: 3n
}
```

This PR is aiming to ignore the error and skip by an empty try catch