### PR TITLE
move return 1002 to above before executing

### DIFF
--- a/packages/signer-test/src/agentChannel.ts
+++ b/packages/signer-test/src/agentChannel.ts
@@ -206,7 +206,7 @@ export class AgentChannel implements Channel {
         const { certificate } = await agent.readState(canisterId, {
           paths: [
             [
-              new TextEncoder().encode("request_status"),
+              new TextEncoder().encode("request_status").buffer,
               submitResponse.requestId,
             ],
           ],
@@ -305,7 +305,7 @@ export class AgentChannel implements Channel {
                   const { certificate } = await agent.readState(canisterId, {
                     paths: [
                       [
-                        new TextEncoder().encode("request_status"),
+                        new TextEncoder().encode("request_status").buffer,
                         submitResponse.requestId,
                       ],
                     ],

--- a/packages/signer-test/src/constants.ts
+++ b/packages/signer-test/src/constants.ts
@@ -43,28 +43,30 @@ export const scopes: Array<{
   scope: PermissionScope;
   state: PermissionState;
 }> = [
-  {
-    scope: {
-      method: "icrc27_accounts",
+    {
+      scope: {
+        method: "icrc27_accounts",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc34_delegation",
+    {
+      scope: {
+        method: "icrc34_delegation",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc49_call_canister",
+    {
+      scope: {
+        method: "icrc49_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc112_batch_call_canister",
+    {
+      scope: {
+        method: "icrc112_batch_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-];
+  ];
+
+export const ICRC_114_METHOD_NAME = "icrc114_validate";

--- a/packages/signer/src/icrc112/batchCallCanister.ts
+++ b/packages/signer/src/icrc112/batchCallCanister.ts
@@ -19,23 +19,20 @@ export type BatchCallCanisterRequest = JsonRequest<
       arg: string;
       nonce?: string;
     }[][];
-    validation?: {
-      canisterId: string;
-      method: string;
-    };
+    validationCanisterId?: string;
   }
 >;
 
 export type BatchCallCanisterResponse = JsonResponse<{
   responses: (
     | {
-        result: {
-          contentMap: string;
-          certificate: string;
-        };
-      }
+      result: {
+        contentMap: string;
+        certificate: string;
+      };
+    }
     | {
-        error: JsonError;
-      }
+      error: JsonError;
+    }
   )[][];
 }>;

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -145,7 +145,7 @@ export class Signer<T extends Transport = Transport> {
     // Establish a new transport channel
     const channel = this.#options.transport.establishChannel();
     // Indicate that transport channel is being established
-    this.#establishingChannel = channel.then(() => {}).catch(() => {});
+    this.#establishingChannel = channel.then(() => { }).catch(() => { });
     // Clear previous transport channel
     this.#channel = undefined;
     // Assign transport channel once established
@@ -364,18 +364,18 @@ export class Signer<T extends Transport = Transport> {
       method: string;
       arg: ArrayBuffer;
     }[][];
-    validation?: { canisterId: Principal; method: string };
+    validationCanisterId?: Principal;
   }): Promise<
     (
       | {
-          result: {
-            contentMap: ArrayBuffer;
-            certificate: ArrayBuffer;
-          };
-        }
+        result: {
+          contentMap: ArrayBuffer;
+          certificate: ArrayBuffer;
+        };
+      }
       | {
-          error: JsonError;
-        }
+        error: JsonError;
+      }
     )[][]
   > {
     const response = await this.sendRequest<
@@ -394,12 +394,7 @@ export class Signer<T extends Transport = Transport> {
             arg: toBase64(request.arg),
           })),
         ),
-        validation: params.validation
-          ? {
-              canisterId: params.validation.canisterId.toText(),
-              method: params.validation.method,
-            }
-          : undefined,
+        validationCanisterId: params.validationCanisterId?.toText(),
       },
     });
     const result = unwrapResponse(response);


### PR DESCRIPTION
follow the [ICRC-112 docs](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_112_batch_call_canister.md#1002-validation-required)

If we provided more than one batch request without `validationCanisterId `, eg:
```
[
   [tx1, tx2],
   [tx3]
]
```

Current code will execute tx1, tx2 and tx3 but tx3 will always return with 1002. This PR use to return 1002 soon because more than one batch request required `validationCanisterId`