### PR TITLE
update ICRC-112 schema for signer 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
           "./packages/signer-extension",
           "./packages/signer-test",
           "./packages/signer-transport-auth-client",
-          "./packages/signer-transport-plug",
           "./packages/signer-transport-stoic"
         ]
       }
@@ -784,10 +783,6 @@
     },
     "node_modules/@slide-computer/signer-transport-auth-client": {
       "resolved": "packages/signer-transport-auth-client",
-      "link": true
-    },
-    "node_modules/@slide-computer/signer-transport-plug": {
-      "resolved": "packages/signer-transport-plug",
       "link": true
     },
     "node_modules/@slide-computer/signer-transport-stoic": {
@@ -1995,6 +1990,7 @@
     "packages/signer-transport-plug": {
       "name": "@slide-computer/signer-transport-plug",
       "version": "3.16.0",
+      "extraneous": true,
       "license": "MIT",
       "peerDependencies": {
         "@dfinity/agent": "^2.3.0",
@@ -2422,10 +2418,6 @@
     },
     "@slide-computer/signer-transport-auth-client": {
       "version": "file:packages/signer-transport-auth-client",
-      "requires": {}
-    },
-    "@slide-computer/signer-transport-plug": {
-      "version": "file:packages/signer-transport-plug",
       "requires": {}
     },
     "@slide-computer/signer-transport-stoic": {

--- a/packages/signer-test/src/constants.ts
+++ b/packages/signer-test/src/constants.ts
@@ -43,28 +43,30 @@ export const scopes: Array<{
   scope: PermissionScope;
   state: PermissionState;
 }> = [
-  {
-    scope: {
-      method: "icrc27_accounts",
+    {
+      scope: {
+        method: "icrc27_accounts",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc34_delegation",
+    {
+      scope: {
+        method: "icrc34_delegation",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc49_call_canister",
+    {
+      scope: {
+        method: "icrc49_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-  {
-    scope: {
-      method: "icrc112_batch_call_canister",
+    {
+      scope: {
+        method: "icrc112_batch_call_canister",
+      },
+      state: "granted",
     },
-    state: "granted",
-  },
-];
+  ];
+
+export const ICRC_114_METHOD_NAME = "icrc114_validate";

--- a/packages/signer/src/icrc112/batchCallCanister.ts
+++ b/packages/signer/src/icrc112/batchCallCanister.ts
@@ -19,23 +19,20 @@ export type BatchCallCanisterRequest = JsonRequest<
       arg: string;
       nonce?: string;
     }[][];
-    validation?: {
-      canisterId: string;
-      method: string;
-    };
+    validationCanisterId?: string;
   }
 >;
 
 export type BatchCallCanisterResponse = JsonResponse<{
   responses: (
     | {
-        result: {
-          contentMap: string;
-          certificate: string;
-        };
-      }
+      result: {
+        contentMap: string;
+        certificate: string;
+      };
+    }
     | {
-        error: JsonError;
-      }
+      error: JsonError;
+    }
   )[][];
 }>;

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -145,7 +145,7 @@ export class Signer<T extends Transport = Transport> {
     // Establish a new transport channel
     const channel = this.#options.transport.establishChannel();
     // Indicate that transport channel is being established
-    this.#establishingChannel = channel.then(() => {}).catch(() => {});
+    this.#establishingChannel = channel.then(() => { }).catch(() => { });
     // Clear previous transport channel
     this.#channel = undefined;
     // Assign transport channel once established
@@ -364,18 +364,18 @@ export class Signer<T extends Transport = Transport> {
       method: string;
       arg: ArrayBuffer;
     }[][];
-    validation?: { canisterId: Principal; method: string };
+    validationCanisterId?: Principal;
   }): Promise<
     (
       | {
-          result: {
-            contentMap: ArrayBuffer;
-            certificate: ArrayBuffer;
-          };
-        }
+        result: {
+          contentMap: ArrayBuffer;
+          certificate: ArrayBuffer;
+        };
+      }
       | {
-          error: JsonError;
-        }
+        error: JsonError;
+      }
     )[][]
   > {
     const response = await this.sendRequest<
@@ -394,12 +394,7 @@ export class Signer<T extends Transport = Transport> {
             arg: toBase64(request.arg),
           })),
         ),
-        validation: params.validation
-          ? {
-              canisterId: params.validation.canisterId.toText(),
-              method: params.validation.method,
-            }
-          : undefined,
+        validationCanisterId: params.validationCanisterId?.toText(),
       },
     });
     const result = unwrapResponse(response);

--- a/packages/signer/src/signer.ts
+++ b/packages/signer/src/signer.ts
@@ -363,6 +363,7 @@ export class Signer<T extends Transport = Transport> {
       canisterId: Principal;
       method: string;
       arg: ArrayBuffer;
+      nonce?: ArrayBuffer;
     }[][];
     validationCanisterId?: Principal;
   }): Promise<
@@ -392,6 +393,7 @@ export class Signer<T extends Transport = Transport> {
             canisterId: request.canisterId.toText(),
             method: request.method,
             arg: toBase64(request.arg),
+            nonce: request.nonce ? toBase64(request.nonce) : undefined,
           })),
         ),
         validationCanisterId: params.validationCanisterId?.toText(),


### PR DESCRIPTION
Before ICRC-114 finalize, the schema of ICRC-112 look like this 
```
// JSON RPC payload
{
 validation: {
  canisterId: string;
  method: string;
 },
 requests: [...]
}
```

But after finalize we agree canister have to implement a method `icrc114_validate` there for ICRC-112 request payload should follow 

```
// JSON RPC payload
{
 validationCanisterId: "xxxxx",
 requests: [...]
}
```